### PR TITLE
Allow migrations to be published

### DIFF
--- a/src/WhizbangServiceProvider.php
+++ b/src/WhizbangServiceProvider.php
@@ -26,7 +26,9 @@ class WhizbangServiceProvider extends ServiceProvider
             __DIR__.'/../config/whizbang.php' => config_path('whizbang.php'),
         ], 'whizbang-config');
 
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        $this->publishesMigrations([
+            __DIR__.'/../database/migrations' => database_path('migrations'),
+        ], 'whizbang-migrations');
 
         if ($this->app->runningInConsole()) {
             $this->commands([


### PR DESCRIPTION
The Whizbang migrations are not published by default and so an error is thrown when `php artisan migrate` is run as it is expecting the Whizbang tables to exist when they aren't. With this change I believe it will allow for them to be published.